### PR TITLE
Moving from HTMLCanvas to XMLSVG-first rendering model + grid "dotted" pattern

### DIFF
--- a/implementation/index.js
+++ b/implementation/index.js
@@ -125,7 +125,7 @@ export const transformSVG = ({HTMLCanvas, XMLSVG, parent}) =>{
                                     );
                                     
                                     // DEV_NOTE (!) # if you really want to see view (shape), make sure you have scaled it to some extent...
-                                    matrix.scaleSelf(stage.grid.GRIDCELL_DIM * ( 1 / Math.cos( Math.PI/4 ) ) , stage.grid.GRIDCELL_DIM * ( 1 / Math.cos( Math.PI/4 ) ));
+                                    matrix.scaleSelf(stage.grid.GRIDCELL_DIM *  ( 1 / Math.cos( Math.PI/4 ) ) , stage.grid.GRIDCELL_DIM * ( 1 / Math.cos( Math.PI/4 ) ));
                                 
                                 return matrix;
     

--- a/implementation/index.js
+++ b/implementation/index.js
@@ -14,10 +14,12 @@ export
             }
             ,
             grid : {
+                name: 'grid',
                 hidden: !true,
+                dotted: !true,
                 lineWidth: 1,
                 strokeStyle: 'grey',
-                opacity: 0.25
+                opacity: 1
             }
         }
         ;

--- a/implementation/primitives.js
+++ b/implementation/primitives.js
@@ -17,16 +17,35 @@ let HOVER_ME_0;
 /**
  * @param  {Object}   `options`                   - the input this function accepts 
  * @param  {String}   [`options.resource`='circle'] - `resource` is symbolic name this function differentiates against (**see `switch` statement `case`s** for current available list of `resource`s) | Default: 'smooth_wave'
+ * > **NOTE**: when it comes about `_wave` view to avoid its graphical artifacts, please phase it horizontally or vertically via `transformSVG` (see `../index.js`)
+
  * @param  {Function} `options.setRangeFn`        - function body passed
  * @return {Object}   `options.Converters`        - forwared `options.Converters` object, originally defined within "`HTMLCanvas`" named module export
  */
 export function diffShape({resource = 'smooth_wave', setRangeFn, Converters}) {
 
-    let stepBasis = 1;
+    const 
+        TAU = 360
+        ,
+        SNAP_TO_GRID = 1 / (1 / Math.sin(Math.PI/4))
+        ;
+
+    const waveConfig = {
+        periods : 1
+        ,
+        frequency: 3
+        ,
+        amplitude : 4
+    }
+    
+    let 
+        stepBasis = 1
+        ;
+
     switch (resource) {
         case 'circle' :
             return (
-                setRangeFn(0, stepBasis, 720).map((deg)=>{
+                setRangeFn(0, stepBasis, TAU*2).map((deg)=>{
                     return {
                         x: 1 * Math.cos( Converters.degToRad( deg ) ),
                         y: 1 * Math.sin( Converters.degToRad( deg ) ),
@@ -35,7 +54,7 @@ export function diffShape({resource = 'smooth_wave', setRangeFn, Converters}) {
             );
         case 'square' :
             return (
-                setRangeFn(0, stepBasis*90, 720).map((deg)=>{
+                setRangeFn(0, stepBasis*90, TAU*2).map((deg)=>{
                     return {
                         x: 1 * Math.cos( Converters.degToRad( deg ) ),
                         y: 1 * Math.sin( Converters.degToRad( deg ) ),
@@ -45,7 +64,7 @@ export function diffShape({resource = 'smooth_wave', setRangeFn, Converters}) {
         ;
         case 'right_triangle' :
             return (
-                setRangeFn(0, stepBasis*270, 720).map((deg)=>{
+                setRangeFn(0, stepBasis*270, TAU*2).map((deg)=>{
                     return {
                         x: 1 * Math.cos( Converters.degToRad( deg ) ),
                         y: 1 * Math.sin( Converters.degToRad( deg ) ),
@@ -55,7 +74,7 @@ export function diffShape({resource = 'smooth_wave', setRangeFn, Converters}) {
         ;
         case 'isosceles' :
             return (
-                setRangeFn(0, stepBasis*300, 720).map((deg)=>{
+                setRangeFn(0, stepBasis*300, TAU*2).map((deg)=>{
                     return {
                         x: 1 * Math.cos( Converters.degToRad( deg ) ),
                         y: 1 * Math.sin( Converters.degToRad( deg ) ),
@@ -65,20 +84,21 @@ export function diffShape({resource = 'smooth_wave', setRangeFn, Converters}) {
         ;
         case 'smooth_wave':
             return (
-                setRangeFn(0, stepBasis*1, 360).map((deg)=>{
+                setRangeFn(0, stepBasis*1, TAU * waveConfig.periods).map((deg)=>{
                     return {
                         x: 1 * /* Math.cos( */ Converters.degToRad( deg ) /* ) */,
-                        y: 1 * Math.sin( Converters.degToRad( deg ) ),
+                        y: (waveConfig.amplitude * SNAP_TO_GRID) * Math.sin( Converters.degToRad( deg )*waveConfig.frequency ),
                     }
                 })
             )
         ;
         case 'triangle_wave':
+            // DEV_NOTE # due to way this wrapper is built, to avoid graphical artifacts, please phase horizontally|vertically via `transformSVG` (see `../index.js`)
             return (
-                setRangeFn(0, stepBasis*90, 360).map((deg)=>{
+                setRangeFn(0, stepBasis*90, TAU * waveConfig.periods).map((deg)=>{
                     return {
                         x: 1 * /* Math.cos( */ Converters.degToRad( deg ) /* ) */,
-                        y: 1 * Math.sin( Converters.degToRad( deg ) ),
+                        y: (waveConfig.amplitude * SNAP_TO_GRID) * Math.sin( Converters.degToRad( deg )*waveConfig.frequency ),
                     }
                 })
             )

--- a/main.js
+++ b/main.js
@@ -22,7 +22,7 @@ document.addEventListener(EVENTS.DOMContentLoaded, ()=>{
         ;
         document.body.children.stage?.add([
             new HTMLCanvas.ViewGroup.Layer({
-                name: userConfigs.grid.name
+                name: userConfigs.grid.name, hidden: !true
             })
             ,
             svgContainer
@@ -37,16 +37,14 @@ document.addEventListener(EVENTS.DOMContentLoaded, ()=>{
                     .on((context)=>{
 
                         if ( context instanceof CanvasRenderingContext2D ) {
-                
-                            const canvas = context.canvas;
-                                                
-                                switch (canvas.name) {
+                                                                
+                                switch (context.canvas.name) {
                 
                                     case stage.layers.grid.name :
 
                                         if (
                                             HTMLCanvas.Views.Grid.draw({
-                                                canvas,
+                                                context,
                                                 options: {
                                                 /* === DEVELOPER IS WELCOME TO MODIFY: === */
                                                     ...userConfigs.grid

--- a/main.js
+++ b/main.js
@@ -22,7 +22,7 @@ document.addEventListener(EVENTS.DOMContentLoaded, ()=>{
         ;
         document.body.children.stage?.add([
             new HTMLCanvas.ViewGroup.Layer({
-                name: 'grid'
+                name: userConfigs.grid.name
             })
             ,
             svgContainer

--- a/src/views/htmlcanvas/grid-view/index.js
+++ b/src/views/htmlcanvas/grid-view/index.js
@@ -25,6 +25,14 @@ export class grid_view {
         /** {@link https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API/Tutorial/Transformations} */
         function drawGrid(x, y, xLen = gridcellDim, yLen = gridcellDim) {
 
+            if (options.dotted){
+                const improveVisibility = (dot)=> dot = dot*stage.grid.GRIDCELL_DIM;
+                [xLen, yLen] = [1/gridcellDim, 1/gridcellDim].map(improveVisibility)
+
+            } else {
+                [xLen, yLen] = [1*gridcellDim, 1*gridcellDim]
+            }
+
             context.beginPath();
             
             if (!canvas.isSkewed) {

--- a/src/views/htmlcanvas/grid-view/index.js
+++ b/src/views/htmlcanvas/grid-view/index.js
@@ -8,15 +8,13 @@ export class grid_view {
      * @param {Object} `options`           - options you have passed to shape's current `context` of the current `canvas` reference
      * @returns {CanvasRenderingContext2D} `context` - the modified `context` with a `grid` view "painted" on the `<canvas>` hosted bitmap
     */
-    static draw({canvas, options}){
+    static draw({context, options}){
 
         let 
             gridcellDim = stage.grid.GRIDCELL_DIM
             ,
-            gridcellMatrix = setRange(0, gridcellDim, canvas.width)
+            gridcellMatrix = setRange(0, gridcellDim, context.canvas.width)
             ;
-
-        const context = canvas.getContext('2d');
         
         context.setTransform(devicePixelRatio, 0, 0, devicePixelRatio, 0, 0);
         context.clearRect(0, 0, context.canvas.width, context.canvas.height);
@@ -35,14 +33,10 @@ export class grid_view {
 
             context.beginPath();
             
-            if (!canvas.isSkewed) {
-                context.rect(x, y, xLen, yLen)
-            } else {
-                context.rect(x, y * canvas.isSkewed.y, xLen, yLen * canvas.isSkewed.y)
-            }
+            context.rect(x, y, xLen, yLen);
             context.kind = options?.kind || 'grid';
-            context.lineWidth = options?.lineWidth || context.global.options.lineWidth;
-            context.strokeStyle = options?.strokeStyle || context.global.options.strokeStyle;
+            context.lineWidth = options?.lineWidth || 1;
+            context.strokeStyle = options?.strokeStyle || 1;
             options.hidden ? false : context.stroke();
 
         }
@@ -73,7 +67,6 @@ export class grid_view {
 
         });
 
-        Object.assign(context, { options });
         return context;
     
     }

--- a/src/views/htmlcanvas/index.js
+++ b/src/views/htmlcanvas/index.js
@@ -1,7 +1,7 @@
 import "./DOMutils.js";
 import { stage_view } from './stage-view/index.js';
 import { layer_view } from './layer-view/index.js';
-import { grid_view } from './grid-view/index.js'
+import { grid_view } from './grid-view/index.js';
 import { degToRad, radToDeg, setTransform, setRange } from "./modules/maths/index.js";
 
 export class HTMLCanvas {
@@ -103,7 +103,7 @@ export class HTMLCanvas {
     }
     
     static Views = {
-        Grid: grid_view
+        Grid: grid_view,
     }
 
     static Helpers = {

--- a/src/views/htmlcanvas/index.js
+++ b/src/views/htmlcanvas/index.js
@@ -33,7 +33,7 @@ export class HTMLCanvas {
          * > This function expression works as a guard against end-user or developer with limited knowledge of Canvas API
          * 
          * @param {Number} num - an "odd" number that is made to be "even", or even number that is left out as is, i.e. "even"
-         * @returns {Number} makes sure the modified `stage.grid.GRIDCELL_DIM` is always even, this makes sure the shapes (a.k.a. views) are well centred within a _"grid-first"_ coordinate system
+         * @returns {Number} makes sure the modified `stage.grid.GRIDCELL_DIM` is always even, this prevents sub-pixel rendering in grid-first coordinate system {@link https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API/Tutorial/Optimizing_canvas#avoid_floating-point_coordinates_and_use_integers_instead}
         */
         static #evenNumber = (num = 0) => {
             const rounded = Math.ceil(num);
@@ -51,9 +51,9 @@ export class HTMLCanvas {
             const
                 GRIDCELL_DIM = ( stage.clientWidth / this.#evenNumber( stage.scale ) )
                 ,
-                divisorX = Math.ceil( stage?.clientWidth / GRIDCELL_DIM )
+                divisorX = Math.ceil( stage.clientWidth / GRIDCELL_DIM )
                 ,
-                divisorY = Math.ceil( stage?.clientHeight / GRIDCELL_DIM )
+                divisorY = Math.ceil( stage.clientHeight / GRIDCELL_DIM )
                 ,
                 X_IN_MIDDLE = ( ( divisorX * GRIDCELL_DIM ) / 2 )
                 ,  
@@ -79,8 +79,8 @@ export class HTMLCanvas {
                 Array.from( stage.children ).forEach((layer)=>{
                     
                     if (layer instanceof HTMLCanvasElement) {
-                        layer.width = stage?.clientWidth * window.devicePixelRatio;
-                        layer.height = stage?.clientHeight * window.devicePixelRatio;
+                        layer.width = stage.clientWidth * window.devicePixelRatio;
+                        layer.height = stage.clientHeight * window.devicePixelRatio;
                     }
 
                 });

--- a/src/views/htmlcanvas/stage-view/index.js
+++ b/src/views/htmlcanvas/stage-view/index.js
@@ -20,9 +20,4 @@ customElements.define(stage_view, class extends HTMLDivElement {
 
     }
 
-    connectedCallback(){
-        this.setAttribute('readonly:width', Math.floor(this.clientWidth * window.devicePixelRatio))  ;
-        this.setAttribute('readonly:height', Math.floor(this.clientHeight * window.devicePixelRatio));
-    }
-
 }, {extends: 'div'})


### PR DESCRIPTION
ACHIEVEMENTS
- added `waveConfig` for future GUI bindings
- added new "dotted" pattern for `grid` view rendering, i.e. `dotted: true`, see [commit](https://github.com/projektorius96/Vekt.js/commit/95b792ae17bb94ab318ccbb248869d15dcfe8613); until "3D-in-2D" grid skewing is properly implemented by offloading to worker thread (in tandem with [OffscreenCanvas API](https://web.dev/articles/offscreen-canvas)), this will help to achieve same effect but without distraction that grid itself is not skewed in sync with the rest of the composition: skewing itself requires that optimisation, otherwise machines with powerful CPU and 16+ RAM may still be choking...