### PR TITLE
Rolling back to the state since commit:dc94a46 (non-breaking changes)

### DIFF
--- a/main.js
+++ b/main.js
@@ -73,22 +73,13 @@ document.addEventListener(EVENTS.DOMContentLoaded, ()=>{
                                                      */
                                                     let HOVER_ME_1;
                                                     stage.layers['grid.bitmaprenderer'].getContext('bitmaprenderer').transferFromImageBitmap(e.data.bitmap)
+                                                    
+                                                    transformSVG({HTMLCanvas, XMLSVG, parent: svgContainer}) ;
 
-                                                })
+                                                    worker$offscreenGrid.terminate();
 
-                                        // if (
-                                        //     HTMLCanvas.Views.Grid.draw({
-                                        //         context,
-                                        //         options: {
-                                        //         /* === DEVELOPER IS WELCOME TO MODIFY: === */
-                                        //             ...userConfigs.grid
-                                        //         /* === DEVELOPER IS WELCOME TO MODIFY; === */
-                                        //         }
-                                        //     })
-                                        // ) 
-                                        
-                                        transformSVG({HTMLCanvas, XMLSVG, parent: svgContainer}) ;
-                                    
+                                                });
+
                                     break;
 
                                 }

--- a/main.js
+++ b/main.js
@@ -46,7 +46,7 @@ document.addEventListener(EVENTS.DOMContentLoaded, ()=>{
                                             HTMLCanvas.Views.Grid.draw({
                                                 context, 
                                                 options: {
-                                                    dotted: true,
+                                                    dotted: userConfigs.grid.dotted,
                                                     lineWidth: 1,
                                                 }}
                                             )

--- a/main.js
+++ b/main.js
@@ -22,12 +22,16 @@ document.addEventListener(EVENTS.DOMContentLoaded, ()=>{
         ;
         document.body.children.stage?.add([
             new HTMLCanvas.ViewGroup.Layer({
-                name: userConfigs.grid.name, hidden: !true
+                name: userConfigs.grid.name, hidden: !true, overrideContext: '2d'
+            })
+            ,
+            new HTMLCanvas.ViewGroup.Layer({
+                name: 'grid.bitmaprenderer', hidden: !true, overrideContext: 'bitmaprenderer'
             })
             ,
             svgContainer
         ])
-
+        
     if ( HTMLCanvas.init({stage}) ) {
 
         window.on(EVENTS.resize, ()=>{
@@ -36,7 +40,7 @@ document.addEventListener(EVENTS.DOMContentLoaded, ()=>{
                 .init({stage})
                     .on((context)=>{
 
-                        if ( context instanceof CanvasRenderingContext2D ) {
+                        if ( context instanceof (CanvasRenderingContext2D || ImageBitmapRenderingContext) ) {
                                                                 
                                 switch (context.canvas.name) {
                 
@@ -56,10 +60,19 @@ document.addEventListener(EVENTS.DOMContentLoaded, ()=>{
                                                 )
 
                                                 worker$offscreenGrid.addEventListener(EVENTS.message, (e)=>{
-                                                    // Draw it back to the visible canvas
-                                                    context.clearRect(0, 0, context.canvas.width, context.canvas.height);
-                                                    context.drawImage(e.data.bitmap, 0, 0, context.canvas.width, context.canvas.height);
-                                                    e.data.bitmap.close();
+                                                    
+                                                    // context.clearRect(0, 0, context.canvas.width, context.canvas.height);
+                                                    // context.drawImage(e.data.bitmap, 0, 0, context.canvas.width, context.canvas.height);
+                                                    // e.data.bitmap.close();
+
+                                                    // ALTERNATIVELY:..
+
+                                                    /**
+                                                     * > NOTE: you do not need to call `close()` on the `ImageBitmap` instance: whenever you call transferFromImageBitmap(), browser automatically does free the resources,..
+                                                     * .. the method called does itself automatically "consume" the `ImageBitmap`, meaning ownership is transferred, and the `ImageBitmap` is no longer valid after the call
+                                                     */
+                                                    let HOVER_ME_1;
+                                                    stage.layers['grid.bitmaprenderer'].getContext('bitmaprenderer').transferFromImageBitmap(e.data.bitmap)
 
                                                 })
 

--- a/main.js
+++ b/main.js
@@ -13,7 +13,7 @@ document.addEventListener(EVENTS.DOMContentLoaded, ()=>{
 
     document.body.appendChild(
         new HTMLCanvas.ViewGroup.Stage({
-                ...userConfigs.canvas
+            ...userConfigs.canvas
         })
     );
 
@@ -22,11 +22,7 @@ document.addEventListener(EVENTS.DOMContentLoaded, ()=>{
         ;
         document.body.children.stage?.add([
             new HTMLCanvas.ViewGroup.Layer({
-                name: userConfigs.grid.name, hidden: !true, overrideContext: '2d'
-            })
-            ,
-            new HTMLCanvas.ViewGroup.Layer({
-                name: 'grid.bitmaprenderer', hidden: !true, overrideContext: 'bitmaprenderer'
+                name: userConfigs.grid.name, hidden: !true
             })
             ,
             svgContainer
@@ -40,45 +36,21 @@ document.addEventListener(EVENTS.DOMContentLoaded, ()=>{
                 .init({stage})
                     .on((context)=>{
 
-                        if ( context instanceof (CanvasRenderingContext2D || ImageBitmapRenderingContext) ) {
+                        if ( context instanceof CanvasRenderingContext2D ) {
                                                                 
                                 switch (context.canvas.name) {
                 
                                     case stage.layers.grid.name :
 
-                                        const offscreenGrid = new OffscreenCanvas(context.canvas.width, context.canvas.height);
-                                            const worker$offscreenGrid = new Worker(`.${HTMLCanvas.Views.Grid.getNamespace()}`, { type: 'module' })
-                                                worker$offscreenGrid
-                                                .postMessage({
-                                                    canvas: offscreenGrid, 
-                                                    grid: { 
-                                                        GRIDCELL_DIM: stage.grid.GRIDCELL_DIM, 
-                                                        DPR: window.devicePixelRatio 
-                                                    }
-                                                }
-                                                    , [ offscreenGrid]
-                                                )
-
-                                                worker$offscreenGrid.addEventListener(EVENTS.message, (e)=>{
-                                                    
-                                                    // context.clearRect(0, 0, context.canvas.width, context.canvas.height);
-                                                    // context.drawImage(e.data.bitmap, 0, 0, context.canvas.width, context.canvas.height);
-                                                    // e.data.bitmap.close();
-
-                                                    // ALTERNATIVELY:..
-
-                                                    /**
-                                                     * > NOTE: you do not need to call `close()` on the `ImageBitmap` instance: whenever you call transferFromImageBitmap(), browser automatically does free the resources,..
-                                                     * .. the method called does itself automatically "consume" the `ImageBitmap`, meaning ownership is transferred, and the `ImageBitmap` is no longer valid after the call
-                                                     */
-                                                    let HOVER_ME_1;
-                                                    stage.layers['grid.bitmaprenderer'].getContext('bitmaprenderer').transferFromImageBitmap(e.data.bitmap)
-                                                    
-                                                    transformSVG({HTMLCanvas, XMLSVG, parent: svgContainer}) ;
-
-                                                    worker$offscreenGrid.terminate();
-
-                                                });
+                                        if (
+                                            HTMLCanvas.Views.Grid.draw({
+                                                context, 
+                                                options: {
+                                                    dotted: true,
+                                                    lineWidth: 1,
+                                                }}
+                                            )
+                                        ) transformSVG({HTMLCanvas, XMLSVG, parent: svgContainer}) ;
 
                                     break;
 

--- a/main.js
+++ b/main.js
@@ -42,16 +42,39 @@ document.addEventListener(EVENTS.DOMContentLoaded, ()=>{
                 
                                     case stage.layers.grid.name :
 
-                                        if (
-                                            HTMLCanvas.Views.Grid.draw({
-                                                context,
-                                                options: {
-                                                /* === DEVELOPER IS WELCOME TO MODIFY: === */
-                                                    ...userConfigs.grid
-                                                /* === DEVELOPER IS WELCOME TO MODIFY; === */
+                                        const offscreenGrid = new OffscreenCanvas(context.canvas.width, context.canvas.height);
+                                            const worker$offscreenGrid = new Worker(`.${HTMLCanvas.Views.Grid.getNamespace()}`, { type: 'module' })
+                                                worker$offscreenGrid
+                                                .postMessage({
+                                                    canvas: offscreenGrid, 
+                                                    grid: { 
+                                                        GRIDCELL_DIM: stage.grid.GRIDCELL_DIM, 
+                                                        DPR: window.devicePixelRatio 
+                                                    }
                                                 }
-                                            })
-                                        ) transformSVG({HTMLCanvas, XMLSVG, parent: svgContainer}) ;
+                                                    , [ offscreenGrid]
+                                                )
+
+                                                worker$offscreenGrid.addEventListener(EVENTS.message, (e)=>{
+                                                    // Draw it back to the visible canvas
+                                                    context.clearRect(0, 0, context.canvas.width, context.canvas.height);
+                                                    context.drawImage(e.data.bitmap, 0, 0, context.canvas.width, context.canvas.height);
+                                                    e.data.bitmap.close();
+
+                                                })
+
+                                        // if (
+                                        //     HTMLCanvas.Views.Grid.draw({
+                                        //         context,
+                                        //         options: {
+                                        //         /* === DEVELOPER IS WELCOME TO MODIFY: === */
+                                        //             ...userConfigs.grid
+                                        //         /* === DEVELOPER IS WELCOME TO MODIFY; === */
+                                        //         }
+                                        //     })
+                                        // ) 
+                                        
+                                        transformSVG({HTMLCanvas, XMLSVG, parent: svgContainer}) ;
                                     
                                     break;
 

--- a/src/views/htmlcanvas/grid-view/index.js
+++ b/src/views/htmlcanvas/grid-view/index.js
@@ -14,7 +14,7 @@ export class grid_view {
      * @param {Object} `options`           - options you have passed to shape's current `context` of the current `canvas` reference
      * @returns {CanvasRenderingContext2D} `context` - the modified `context` with a `grid` view "painted" on the `<canvas>` hosted bitmap
     */
-    static draw({hostContext, context, options}){
+    static draw({context, options}){
 
         let 
             gridcellDim = /* stage.grid.GRIDCELL_DIM */options.grid.GRIDCELL_DIM
@@ -94,11 +94,9 @@ self.onmessage = function (e) {
             }
         });
 
-    /* console.log(context); */// [PASSING]
-
     const bitmap = context.canvas.transferToImageBitmap();
 
-    // Send ImageBitmap to main thread
-    self.postMessage({ bitmap }, [bitmap]); // Transfer ownership
+    // DEV_NOTE # send ImageBitmap to the main thread
+    self.postMessage({ bitmap }, [bitmap]);
     
 }

--- a/src/views/htmlcanvas/grid-view/index.js
+++ b/src/views/htmlcanvas/grid-view/index.js
@@ -16,8 +16,9 @@ export class grid_view {
             gridcellMatrix = setRange(0, gridcellDim, context.canvas.width)
             ;
         
-        context.setTransform(...[1, 0, 0, 1, 0, 0].map((abcdef)=>abcdef = abcdef*devicePixelRatio));
+        context.setTransform(devicePixelRatio, 0, 0, devicePixelRatio, 0, 0);
         context.clearRect(0, 0, context.canvas.width, context.canvas.height);
+        
         
         /** {@link https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API/Tutorial/Transformations} */
         function drawGrid(x, y, xLen = gridcellDim, yLen = gridcellDim) {
@@ -41,7 +42,7 @@ export class grid_view {
         }
 
         let
-            divisorX = Math.ceil( stage.clientWidth  / gridcellDim )
+            divisorX = Math.ceil( stage.clientWidth / gridcellDim )
             ,
             divisorY = Math.ceil( stage.clientHeight / gridcellDim )
         ;

--- a/src/views/htmlcanvas/grid-view/index.js
+++ b/src/views/htmlcanvas/grid-view/index.js
@@ -2,12 +2,6 @@ import { setRange } from "../modules/maths/index.js";
 
 export class grid_view {
 
-    static getNamespace(){
-        return (
-            (new URL(import.meta.url)).pathname
-        )
-    }
-
     /**
      * The `default.draw` static method takes single `Object` as its input whose properties are as follows:
      * @param {HTMLCanvasElement} `canvas` - a reference to `canvas` (_a.k.a. "Layer"_)
@@ -17,19 +11,19 @@ export class grid_view {
     static draw({context, options}){
 
         let 
-            gridcellDim = /* stage.grid.GRIDCELL_DIM */options.grid.GRIDCELL_DIM
+            gridcellDim = stage.grid.GRIDCELL_DIM
             ,
             gridcellMatrix = setRange(0, gridcellDim, context.canvas.width)
             ;
         
-        context.setTransform(...[1, 0, 0, 1, 0, 0].map((abcdef)=>abcdef = abcdef*options.grid.DPR));
+        context.setTransform(...[1, 0, 0, 1, 0, 0].map((abcdef)=>abcdef = abcdef*devicePixelRatio));
         context.clearRect(0, 0, context.canvas.width, context.canvas.height);
         
         /** {@link https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API/Tutorial/Transformations} */
         function drawGrid(x, y, xLen = gridcellDim, yLen = gridcellDim) {
 
             if (options.dotted){
-                const improveVisibility = (dot)=> dot = dot*options.grid.GRIDCELL_DIM/* stage.grid.GRIDCELL_DIM */;
+                const improveVisibility = (dot)=> dot = dot*stage.grid.GRIDCELL_DIM;
                 [xLen, yLen] = [1/gridcellDim, 1/gridcellDim].map(improveVisibility)
 
             } else {
@@ -47,9 +41,9 @@ export class grid_view {
         }
 
         let
-            divisorX = Math.ceil( /* stage */context.canvas.width/* clientWidth  */ / gridcellDim )
+            divisorX = Math.ceil( stage.clientWidth  / gridcellDim )
             ,
-            divisorY = Math.ceil( /* stage */context.canvas.height/* clientHeight */ / gridcellDim )
+            divisorY = Math.ceil( stage.clientHeight / gridcellDim )
         ;
         ;[...new Array(divisorY)].map((v, row)=>{
 
@@ -72,31 +66,8 @@ export class grid_view {
 
         });
 
-
-
         return context;
     
     }
 
-}
-
-self.onmessage = function (e) {
-    
-    const context 
-        = grid_view.draw({
-            hostContext: e.data.hostContext,
-            context: e.data.canvas.getContext('2d'),
-            options: {
-                grid: {
-                    GRIDCELL_DIM: e.data.grid.GRIDCELL_DIM,
-                    DPR: e.data.grid.DPR
-                }
-            }
-        });
-
-    const bitmap = context.canvas.transferToImageBitmap();
-
-    // DEV_NOTE # send ImageBitmap to the main thread
-    self.postMessage({ bitmap }, [bitmap]);
-    
 }

--- a/src/views/htmlcanvas/index.js
+++ b/src/views/htmlcanvas/index.js
@@ -18,9 +18,9 @@ export class HTMLCanvas {
                 return (
                     this.#getIterable(stage.layers)
                         .map(canvas => {
-                            if (canvas instanceof HTMLCanvasElement) {
+                            if (canvas instanceof HTMLCanvasElement) {                            
                                 return (
-                                    canvas = canvas.getContext('2d')
+                                    canvas = canvas.getContext(canvas.overrideContext)
                                 );
                             }
                         })

--- a/src/views/htmlcanvas/index.js
+++ b/src/views/htmlcanvas/index.js
@@ -20,7 +20,7 @@ export class HTMLCanvas {
                         .map(canvas => {
                             if (canvas instanceof HTMLCanvasElement) {                            
                                 return (
-                                    canvas = canvas.getContext(canvas.overrideContext)
+                                    canvas = canvas.getContext('2d')
                                 );
                             }
                         })

--- a/src/views/htmlcanvas/layer-view/index.js
+++ b/src/views/htmlcanvas/layer-view/index.js
@@ -7,7 +7,6 @@ customElements.define(layer_view, class extends HTMLCanvasElement {
 
         if ( setStyling.call( super() , {opacity, hidden} ) ) {
 
-            this.overrideContext = overrideContext || '2d'
             this.name = name;
                 this.id = this.name;
             this.isSkewed = isSkewed;
@@ -15,7 +14,6 @@ customElements.define(layer_view, class extends HTMLCanvasElement {
 
         }
 
-        Object.assign(this, {overrideContext})
         return this;
 
     }
@@ -25,7 +23,7 @@ customElements.define(layer_view, class extends HTMLCanvasElement {
         const
             canvasLayer = this
             ,
-            canvasLayerContext = canvasLayer.getContext(this.overrideContext || '2d')
+            canvasLayerContext = canvasLayer.getContext('2d')
             ;
         
         Object.assign(canvasLayer, Object.freeze({

--- a/src/views/htmlcanvas/layer-view/index.js
+++ b/src/views/htmlcanvas/layer-view/index.js
@@ -3,10 +3,11 @@ import setStyling from './index.css.js';
 export const layer_view = (new URL(import.meta.url)).pathname.split('/').at(-2);
 customElements.define(layer_view, class extends HTMLCanvasElement {
     
-    constructor({name, opacity, hidden, isSkewed}){
+    constructor({name, opacity, hidden, isSkewed, overrideContext}){
 
         if ( setStyling.call( super() , {opacity, hidden} ) ) {
 
+            this.overrideContext = overrideContext || '2d'
             this.name = name;
                 this.id = this.name;
             this.isSkewed = isSkewed;
@@ -14,6 +15,7 @@ customElements.define(layer_view, class extends HTMLCanvasElement {
 
         }
 
+        Object.assign(this, {overrideContext})
         return this;
 
     }
@@ -23,7 +25,7 @@ customElements.define(layer_view, class extends HTMLCanvasElement {
         const
             canvasLayer = this
             ,
-            canvasLayerContext = canvasLayer.getContext('2d')
+            canvasLayerContext = canvasLayer.getContext(this.overrideContext || '2d')
             ;
         
         Object.assign(canvasLayer, Object.freeze({


### PR DESCRIPTION
As titled, see [commit:dc94a46](https://github.com/projektorius96/Vekt.js/commit/dc94a46fcab9647bb4a24409abcaa64a95fc3d36)

---

> **NOTE: this whole rolling back procedure was done manually**, all I had to do, was to remove so far _failing_ worker-driven offscreen skewed `grid` view (see [branch:worker.grid-view](https://github.com/projektorius96/Vekt.js/tree/worker.grid-view))